### PR TITLE
Address IOActive code review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.6.2
+
+### Enhancements
+
+* Better error message for:
+  * `OpenPGP.Util.public_key_algo_tuple/1`
+  * `OpenPGP.Util.sym_algo_tuple/1`
+  * `OpenPGP.Util.sym_algo_cipher_block_size/1`
+  * `OpenPGP.Util.sym_algo_key_size/1`
+
 ## v0.6.0
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * `OpenPGP.Util.sym_algo_tuple/1`
   * `OpenPGP.Util.sym_algo_cipher_block_size/1`
   * `OpenPGP.Util.sym_algo_key_size/1`
+* Updated Elixir supported version to `~>1.14`
 
 ## v0.6.0
 

--- a/lib/open_pgp/public_key_encrypted_session_key_packet.ex
+++ b/lib/open_pgp/public_key_encrypted_session_key_packet.ex
@@ -110,10 +110,21 @@ defmodule OpenPGP.PublicKeyEncryptedSessionKeyPacket do
   Decode Public-Key Encrypted Session Key Packet given input binary.
   Return structured packet and remaining binary.
   """
+  @decode_error """
+  Expected Public-Key Encrypted Session Key Packet to start with 10 bytes sequence:
+    - A one-octet number giving the version number of the packet type.
+    - An eight-octet number that gives the Key ID of the public key to
+      which the session key is encrypted.
+    - A one-octet number giving the public-key algorithm used.
+  """
   @impl OpenPGP.Packet.Behaviour
   @spec decode(binary()) :: {t(), <<>>}
   def decode("" <> _ = input) do
-    <<version::8, pub_key_id::bytes-size(8), pub_key_algo, ciphertext::binary>> = input
+    {version, pub_key_id, pub_key_algo, ciphertext} =
+      case input do
+        <<ver::8, pk_id::bytes-size(8), algo::8, ciphertext::binary>> -> {ver, pk_id, algo, ciphertext}
+        _ -> raise(@decode_error <> " Got #{byte_size(input)} bytes of " <> inspect(input, binaries: :as_binaries))
+      end
 
     packet = %__MODULE__{
       version: version,

--- a/lib/open_pgp/public_key_encrypted_session_key_packet.ex
+++ b/lib/open_pgp/public_key_encrypted_session_key_packet.ex
@@ -123,7 +123,7 @@ defmodule OpenPGP.PublicKeyEncryptedSessionKeyPacket do
     {version, pub_key_id, pub_key_algo, ciphertext} =
       case input do
         <<ver::8, pk_id::bytes-size(8), algo::8, ciphertext::binary>> -> {ver, pk_id, algo, ciphertext}
-        _ -> raise(@decode_error <> " Got #{byte_size(input)} bytes of " <> inspect(input, binaries: :as_binaries))
+        _ -> raise(@decode_error <> "\nGot #{byte_size(input)} byte(s) of " <> inspect(input, binaries: :as_binaries))
       end
 
     packet = %__MODULE__{

--- a/lib/open_pgp/util.ex
+++ b/lib/open_pgp/util.ex
@@ -118,6 +118,11 @@ defmodule OpenPGP.Util do
   }
   @public_key_ids Map.keys(@public_key_algos)
 
+  @pk_algo_error """
+  Expected public key algo ID to be one of:
+  #{@public_key_algos |> Enum.map(&"#{elem(&1, 0)} - #{elem(&1, 1)}") |> Enum.join("\n")}
+  """
+
   @doc """
   Convert public-key algorithm ID to a tuple with ID and name binary.
 
@@ -148,6 +153,8 @@ defmodule OpenPGP.Util do
   @spec public_key_algo_tuple(1..255) :: public_key_algo_tuple()
   def public_key_algo_tuple(algo) when algo in @public_key_ids,
     do: {algo, @public_key_algos[algo]}
+
+  def public_key_algo_tuple(algo), do: raise(@pk_algo_error <> "\nGot: #{inspect(algo)}")
 
   @sym_algos %{
     0 => {"Plaintext or unencrypted data", 0, 0},

--- a/lib/open_pgp/util.ex
+++ b/lib/open_pgp/util.ex
@@ -157,6 +157,7 @@ defmodule OpenPGP.Util do
   def public_key_algo_tuple(algo), do: raise(@pk_algo_error <> "\nGot: #{inspect(algo)}")
 
   @sym_algos %{
+    # => {name, cipher_block_size, key_size}
     0 => {"Plaintext or unencrypted data", 0, 0},
     1 => {"IDEA [IDEA]", 64, 128},
     2 => {"TripleDES (DES-EDE, [SCHNEIER] [HAC] - 168 bit key derived from 192)", 64, 192},
@@ -184,6 +185,11 @@ defmodule OpenPGP.Util do
     110 => {"Private/Experimental algorithm", nil, nil}
   }
   @sym_algo_ids Map.keys(@sym_algos)
+
+  @sym_algo_error """
+  Expected sym. algo ID to be one of:
+  #{@sym_algos |> Enum.map(&"#{elem(&1, 0)} - #{elem(elem(&1, 1), 0)}") |> Enum.join("\n")}
+  """
 
   @doc """
   Convert symmetric encryption algorithm ID to a tuple with ID and name binary.
@@ -216,6 +222,7 @@ defmodule OpenPGP.Util do
   """
   @spec sym_algo_tuple(byte()) :: sym_algo_tuple()
   def sym_algo_tuple(algo) when algo in @sym_algo_ids, do: {algo, elem(@sym_algos[algo], 0)}
+  def sym_algo_tuple(algo), do: raise(@sym_algo_error <> "\nGot: #{inspect(algo)}")
 
   @doc """
   Detects cipher block size (bits) given symmetric encryption algorithm ID or a tuple.
@@ -223,6 +230,7 @@ defmodule OpenPGP.Util do
   @spec sym_algo_cipher_block_size(byte() | sym_algo_tuple()) :: non_neg_integer()
   def sym_algo_cipher_block_size({algo, _}), do: sym_algo_cipher_block_size(algo)
   def sym_algo_cipher_block_size(algo) when algo in @sym_algo_ids, do: elem(@sym_algos[algo], 1)
+  def sym_algo_cipher_block_size(algo), do: raise(@sym_algo_error <> "\nGot: #{inspect(algo)}")
 
   @doc """
   Detects cipher key size (bits) given symmetric encryption algorithm ID or a tuple.
@@ -230,6 +238,7 @@ defmodule OpenPGP.Util do
   @spec sym_algo_key_size(byte() | sym_algo_tuple()) :: non_neg_integer()
   def sym_algo_key_size({algo, _}), do: sym_algo_key_size(algo)
   def sym_algo_key_size(algo) when algo in @sym_algo_ids, do: elem(@sym_algos[algo], 2)
+  def sym_algo_key_size(algo), do: raise(@sym_algo_error <> "\nGot: #{inspect(algo)}")
 
   @comp_algos %{
     0 => "Uncompressed",

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule OpenPGP.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/DivvyPayHQ/open_pgp"
-  @version "0.6.1"
+  @version "0.6.2"
   @description "OpenPGP Message Format in Elixir - RFC4880"
 
   def project() do


### PR DESCRIPTION
### Address infosec code review findings by IOActive:

* `BILL-LIB01`
* `BILL-LIB02`
* `BILL-LIB03`

### Changes summary
* Better error message for:
  * `OpenPGP.Util.public_key_algo_tuple/1`
  * `OpenPGP.Util.sym_algo_tuple/1`
  * `OpenPGP.Util.sym_algo_cipher_block_size/1`
  * `OpenPGP.Util.sym_algo_key_size/1`
