### PR TITLE
CI image updated. Added Elixir 1.18 to a testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,19 @@ permissions:
 jobs:
   unit_tests:
     name: Unit tests Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
         include:
+          - elixir: "1.18"
+            otp: "27"
           - elixir: "1.16"
             otp: "26"
           - elixir: "1.15"
             otp: "26"
           - elixir: "1.14"
             otp: "25"
-          - elixir: "1.13"
-            otp: "24"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Github CI runners have disabled the ubuntu 20.04 LTS. Switching to a `latest` tag.