### PR TITLE
CI image updated. Added Elixir 1.18 to a testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,19 @@ permissions:
 jobs:
   unit_tests:
     name: Unit tests Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
         include:
+          - elixir: "1.18"
+            otp: "27"
           - elixir: "1.16"
             otp: "26"
           - elixir: "1.15"
             otp: "26"
           - elixir: "1.14"
             otp: "25"
-          - elixir: "1.13"
-            otp: "24"
 
     steps:
       - name: Checkout

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule OpenPGP.MixProject do
     [
       app: :open_pgp,
       version: @version,
-      elixir: "~> 1.13",
+      elixir: "~> 1.14",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       description: @description,


### PR DESCRIPTION
* Using `ubuntu-latest` CI image
* Added Elixir 1.18 OPT27 to the testing matrix
* Removed Elixir 1.13 OTP24 from the testing matrix